### PR TITLE
Deprecate Enable and ListEnable classes since v0.9.0

### DIFF
--- a/rune/package.json
+++ b/rune/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rune-ts",
-  "version": "0.8.14",
+  "version": "0.9.0",
   "description": "Rune Core Library",
   "engines": {
     "node": ">=14.0.0"

--- a/rune/src/Enable.ts
+++ b/rune/src/Enable.ts
@@ -2,6 +2,11 @@ import { type View } from './View';
 import { Base } from './Base';
 import { ViewMounted, ViewRendered, ViewUnmounted } from './ViewEvent';
 
+/**
+ * @deprecated
+ * This class has been deprecated since v0.9.0 and will be removed in a future release.
+ * It shouldn’t be used in new projects.
+ */
 export abstract class Enable<T extends object = object> extends Base {
   constructor(public view: View<T>) {
     super();
@@ -15,6 +20,12 @@ export abstract class Enable<T extends object = object> extends Base {
     }
     this.view.addEventListener(ViewMounted, () => this._onMount());
     this.view.addEventListener(ViewUnmounted, () => this._onUnmount());
+
+    console.warn(
+      "[DEPRECATED] Enable class has been deprecated since v0.9.0 and will be removed in a future release. It shouldn’t be used in new projects.\n" +
+      "Stack Trace:\n",
+      new Error().stack
+    );
   }
 
   get data() {

--- a/rune/src/ListEnable.ts
+++ b/rune/src/ListEnable.ts
@@ -1,3 +1,9 @@
 import { Enable } from './Enable';
 
-export abstract class ListEnable<T> extends Enable<T[]> {}
+/**
+ * @deprecated
+ * This class has been deprecated since v0.9.0 and will be removed in a future release.
+ * It shouldn’t be used in new projects.
+ */
+export abstract class ListEnable<T> extends Enable<T[]> {
+}


### PR DESCRIPTION
This PR marks the `Enable` and `ListEnable` classes as deprecated starting from v0.9.0. These classes should no longer be used in new projects and will be removed in a future release.

**Changes**
- Added @deprecated JSDoc comments to `Enable` and `ListEnable` classes.
- Introduced console.warn() to notify developers when these classes are instantiated.