### PR TITLE
fix: prevent duplicate tags if have &(ampersand) and are in SSR (isSSR = true) mode

### DIFF
--- a/rune/src/VirtualView.ts
+++ b/rune/src/VirtualView.ts
@@ -60,19 +60,19 @@ export class VirtualView<T extends object> extends Base {
         ? html.replace("class='", `${runeDataset} class='${className} `)
         : html.replace(`<${startTagName}`, `<${startTagName} ${runeDataset} class="${className}"`);
 
-        return isSSR
-        ? `${html}<script class="__RUNE_DATA__ ${this}" type="application/json" data-rune-base-name="${
-            this._base_name
-          }">${_htmlEscapeJsonString(
-            JSON.stringify({
-              data: this.data,
-              args: this._args,
-              sharedData: rune.getSharedData(this),
-              key: this.key,
-              name: this.constructor.name,
-            })
-          )}</script>`
-        : html;
+    return isSSR
+      ? `${html}<script class="__RUNE_DATA__ ${this}" type="application/json" data-rune-base-name="${
+          this._base_name
+        }">${_htmlEscapeJsonString(
+          JSON.stringify({
+            data: this.data,
+            args: this._args,
+            sharedData: rune.getSharedData(this),
+            key: this.key,
+            name: this.constructor.name,
+          })
+        )}</script>`
+      : html;
   }
 
   protected _currentInnerHtml(): string {

--- a/rune/src/VirtualView.ts
+++ b/rune/src/VirtualView.ts
@@ -69,6 +69,7 @@ export class VirtualView<T extends object> extends Base {
               args: this._args,
               sharedData: rune.getSharedData(this),
               key: this.key,
+              name: this.constructor.name,
             })
           )}</script>`
         : html;

--- a/rune/src/VirtualView.ts
+++ b/rune/src/VirtualView.ts
@@ -62,8 +62,8 @@ export class VirtualView<T extends object> extends Base {
 
     return isSSR
       ? html.replace(
-          html,
-          `${html}<script class="__RUNE_DATA__ ${this}" type="application/json" data-rune-base-name="${this._base_name}">${_htmlEscapeJsonString(
+          /(<\/\w+>)$/,
+          `$1<script class="__RUNE_DATA__ ${this}" type="application/json" data-rune-base-name="${this._base_name}">${_htmlEscapeJsonString(
             JSON.stringify({
               data: this.data,
               args: this._args,

--- a/rune/src/VirtualView.ts
+++ b/rune/src/VirtualView.ts
@@ -60,19 +60,18 @@ export class VirtualView<T extends object> extends Base {
         ? html.replace("class='", `${runeDataset} class='${className} `)
         : html.replace(`<${startTagName}`, `<${startTagName} ${runeDataset} class="${className}"`);
 
-    return isSSR
-      ? html.replace(
-          /(<\/\w+>)$/,
-          `$1<script class="__RUNE_DATA__ ${this}" type="application/json" data-rune-base-name="${this._base_name}">${_htmlEscapeJsonString(
+        return isSSR
+        ? `${html}<script class="__RUNE_DATA__ ${this}" type="application/json" data-rune-base-name="${
+            this._base_name
+          }">${_htmlEscapeJsonString(
             JSON.stringify({
               data: this.data,
               args: this._args,
               sharedData: rune.getSharedData(this),
               key: this.key,
-            }),
-          )}</script>`,
-        )
-      : html;
+            })
+          )}</script>`
+        : html;
   }
 
   protected _currentInnerHtml(): string {


### PR DESCRIPTION
## Reasoning

`_addRuneAttrs` method of the `VirtualView class` is generating duplicate HTML when in `isSSR mode` and contains an `ampersand (&)`.


```typescript
class DuplicationComponent extends View {
  protected template() {
    return html`
      <div class="main">
        <h3>DuplicationComponent Component</h3>
        <p>ABC$&amp;\\:또→😊</p>
      </div>
    `;
  }
}

class Main extends Page<{}> {
  protected template() {
    return html`
      <div>
        <h1>Main Page</h1>
        <div>${new DuplicationComponent({}).toHtmlSSR()}</div>
      </div>
    `;
  }
}

// ------------ result html --------------
//
// <div data-rune="Main" data-rune-parent="null" class="Main">
//        <h1>Main Page</h1>
//        <div><div data-rune="DuplicationComponent" data-rune-parent="null" class="DuplicationComponent main">
//        <h3>DuplicationComponent Component</h3>
//        <p>ABC<div data-rune="DuplicationComponent" data-rune-parent="null" class="DuplicationComponent main">
//        <h3>DuplicationComponent Component</h3>
//        <p>ABC$&amp;\:또→😊</p>
//      </div>amp;\:또→😊</p>
//      </div><script class="__RUNE_DATA__ DuplicationComponent" type="application/json" data-rune-base-name="View">{"data":{},"args":[],"key":""}</script></div>
//      </div>

// ------------ expected correct html --------------
//
// <div data-rune="Main" data-rune-parent="null" class="Main">
//        <h1>Main Page</h1>
//        <div><div data-rune="DuplicationComponent" data-rune-parent="null" class="DuplicationComponent main">
//        <h3>DuplicationComponent Component</h3>
//        <p>ABC$&amp;\:또→😊</p>
//      </div><script class="__RUNE_DATA__ DuplicationComponent" type="application/json" data-rune-base-name="View">{"data":{},"args":[],"key":""}</script></div>
//      </div>
```

When an ampersand (&) is included inside the HTML, it is already converted into an HTML entity (&amp;), so replace does not work as expected.

Since &amp; is reinterpreted as &, a new HTML string is generated, resulting in duplicated HTML.

The regexp for replace has been modified as shown below, referencing the regexp group using $1.

```typescript
return isSSR
      ? html.replace(
          /(<\/\w+>)$/,
          `$1<script class="__RUNE_DATA__ ${this}" type="application/json" data-rune-base-name="${
            this._base_name
          }">${_htmlEscapeJsonString(
            JSON.stringify({
              data: this.data,
              args: this._args,
              sharedData: rune.getSharedData(this),
              key: this.key,
            })
          )}</script>`
        )
      : html;
```

or just think of adding html + script.

```typescript
   return isSSR
      ? `${html}<script class="__RUNE_DATA__ ${this}" type="application/json" data-rune-base-name="${
          this._base_name
        }">${_htmlEscapeJsonString(
          JSON.stringify({
            data: this.data,
            args: this._args,
            sharedData: rune.getSharedData(this),
            key: this.key,
          })
        )}</script>`
      : html;
```

## Changes
- modify `_addRuneAttrs` method of the `VirtualView class`.