### PR TITLE
docs: fix typos in render and hydration docs and update example to use $.all()

### DIFF
--- a/docs/api/$element.md
+++ b/docs/api/$element.md
@@ -19,7 +19,7 @@ const div: $Element = $('div')!;
 `static all(selector: string): $Element[];`
 
 ```typescript
-const divs: $Element[] = $('div');
+const divs: $Element[] = $.all('div');
 ```
 
 ## static $.fromHtml()

--- a/docs/ko/api/$element.md
+++ b/docs/ko/api/$element.md
@@ -19,7 +19,7 @@ const div: $Element = $('div')!;
 `static all(selector: string): $Element[];`
 
 ```typescript
-const divs: $Element[] = $('div');
+const divs: $Element[] = $.all('div');
 ```
 
 ## static $.fromHtml()

--- a/docs/ko/tutorial/solo-component-ssr.md
+++ b/docs/ko/tutorial/solo-component-ssr.md
@@ -52,7 +52,7 @@ new ProductView({
 
 ## Hydration
 
-서버 측에서 HTML을 생성할 당시 사용했던 동일한 데이터를 전달하여 View 객체를 생성한 다음 도큐먼트에 생성되어있는 HTMLElement를 `hydrateFormSSR` 메서드에 전달하면 됩니다.
+서버 측에서 HTML을 생성할 당시 사용했던 동일한 데이터를 전달하여 View 객체를 생성한 다음 도큐먼트에 생성되어있는 HTMLElement를 `hydrateFromSSR` 메서드에 전달하면 됩니다.
 
 ```typescript
 // Client Side

--- a/docs/ko/tutorial/view.md
+++ b/docs/ko/tutorial/view.md
@@ -50,7 +50,7 @@ colorView.chain((view) => (view.data.code = 'blue')).toHtml();
 
 ## HTMLElement 생성하기
 
-`colorView.render();` 를 실행하면 HTMLElement 생성하여 리턴합니다. `render` 메서드는 브라우저단에서만 사용하는 것을 권장합니다.
+`colorView.render();` 를 실행하면 HTMLElement를 생성하여 리턴합니다. `render` 메서드는 브라우저단에서만 사용하는 것을 권장합니다.
 
 ```typescript
 document.body.appendChild(new ColorView({ code: 'pink' }).render());


### PR DESCRIPTION
Only documentation changes: fixes typos in the render method description and hydration method name, and updates the example to use $.all().