### PR TITLE
fix: Ensure onMount is called during SSR hydration

### DIFF
--- a/examples/todo-setting/src/app/lib/CheckView.ts
+++ b/examples/todo-setting/src/app/lib/CheckView.ts
@@ -5,12 +5,4 @@ export class CheckView extends ToggleView {
   override template() {
     return html` <span class="${this.data.on ? 'on' : ''}"></span> `;
   }
-
-  override onMount(): void {
-    console.log('CheckView mounted');
-  }
-
-  override onUnmount(): void {
-    console.log('CheckView unmounted');
-  }
 }


### PR DESCRIPTION
## Summary
- Fix `onMount` lifecycle hook not being called during SSR hydration
- Simplify hydration logic by removing unnecessary `isSSR` parameter
