### PR TITLE
fix: comment out rune.delete

### DIFF
--- a/packages/rune/src/rune.ts
+++ b/packages/rune/src/rune.ts
@@ -94,6 +94,7 @@ class Rune {
           [subViewElement, ...subViewElement.querySelectorAll('[data-rune]')].forEach((element) => {
             if (element.matches('[data-rune]')) {
               const view = rune.getUnknownView(element as HTMLElement);
+              // console.log(view);
               if (view) {
                 addedViewsMap.set(view.viewId, { element: element as HTMLElement, view });
               }
@@ -123,7 +124,7 @@ class Rune {
 
         dispatchEvents(ViewUnmounted, element, true);
 
-        rune.delete(element);
+        // rune.delete(element);
       }
 
       for (const [viewId, { element }] of addedViewsMap) {


### PR DESCRIPTION
Issues arose when directly removing elements(`element.remove()`), so `rune.delete` was temporarily commented out.